### PR TITLE
Replace support.adyen.com references with adyen.help

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Adyen Support
-    url: https://support.adyen.com/hc/en-us/requests/new?ticket_form_id=360000705420
+    url: https://www.adyen.help/hc/en-us/requests/new
     about: For other questions, contact our support team

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Explain how to use after installation.
 Link to relevant documentation and next steps that have to be taken.
 
 ## Support
-If you have a feature request, or spotted a bug or a technical problem, create a GitHub issue. For other questions, contact our [support team](https://support.adyen.com/hc/en-us/requests/new?ticket_form_id=360000705420).    
+If you have a feature request, or spotted a bug or a technical problem, create a GitHub issue. For other questions, contact our [support team](https://www.adyen.help/hc/en-us/requests/new).    
 
 ## License    
 MIT license. For more information, see the LICENSE file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
 # Reporting Security Issues
 
 We welcome reports of possible vulnerabilities or issues as part of our responsible disclosure program. For more information go to
-https://support.adyen.com/hc/en-us/articles/115001187330-How-do-I-report-a-possible-security-issue-to-Adyen
+https://www.adyen.help/hc/en-us/articles/5041452228380-How-do-I-report-a-possible-security-issue-to-Adyen-

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,5 +3,5 @@
 If you're seeking for support there are many options, check out:
 
 * [Documentation](https://docs.adyen.com)
-* [Support](https://support.adyen.com/hc/en-us)
-* [Contact our support team](https://support.adyen.com/hc/en-us/requests/new?ticket_form_id=360000705420)
+* [Support](https://adyen.help/hc/en-us)
+* [Contact our support team](https://www.adyen.help/hc/en-us/requests/new)


### PR DESCRIPTION
`support.adyen.com` is not reachable anymore, updated references to use `adyen.help` domain.